### PR TITLE
Refactor draggable components

### DIFF
--- a/src/components/Background.js
+++ b/src/components/Background.js
@@ -82,12 +82,14 @@ export default class Background extends React.Component {
 
     addCloud= (flowID, from, to) => {
         if(from && to && from.trim().length>0 && to.trim().length>0) return
-        const isOrigin = from ? false:true
-        let clouds = isOrigin ? this.state.cloudsOrigin:this.state.cloudsDestination        
+        if(!from && !to) return        
+        let clouds = this.state.clouds
         clouds = Object.assign([], clouds)
-        const ref = isOrigin?this._FB_PATH+'state/cloudsOrigin':this._FB_PATH+'state/cloudsDestination'
+        const ref = this._FB_PATH+'state/clouds'
         const newCloud = {
             "flow":flowID,
+            "flowFrom": from,
+            "flowTo":to,
             "posX": 0,
             "posY": 0,
         }
@@ -175,6 +177,7 @@ export default class Background extends React.Component {
             cloudsOrigin: [],
             cloudsDestination: [],
             parameters: [],
+            clouds:[],
         }
     }
 
@@ -194,8 +197,7 @@ export default class Background extends React.Component {
                         flows={this.state.flows}
                         arrows={this.state.arrows}
                         parameters={this.state.parameters}
-                        cloudsOrigin={this.state.cloudsOrigin}
-                        cloudsDestination={this.state.cloudsDestination}
+                        clouds={this.state.clouds}
                         stockBeingEdited={this.state.stockBeingEdited}
                         updatePosition={this.updatePosition}    
                         updateCloudPosition={this.updateCloudPosition}

--- a/src/components/Background.js
+++ b/src/components/Background.js
@@ -45,21 +45,6 @@ export default class Background extends React.Component {
         firebase.database().ref(this._FB_PATH+'state/parameters').set(parameters);
     }
 
-    updateCloudPosition = (cloudByFlow, x, y) => {
-        let targetCloud
-        const cloudsOrigin = Object.assign([], this.state.cloudsOrigin)
-        const cloudsDestination = Object.assign([], this.state.cloudsDestination)
-        if(cloudsOrigin.find(cloud => cloud.flow === cloudByFlow)){
-            targetCloud = cloudsOrigin.find(cloud => cloud.flow === cloudByFlow)
-        } else {
-            targetCloud = cloudsDestination.find(cloud => cloud.flow === cloudByFlow)
-        }
-        targetCloud.posX = x
-        targetCloud.posY = y
-        firebase.database().ref(this._FB_PATH+'state/cloudsOrigin').set(cloudsOrigin);
-        firebase.database().ref(this._FB_PATH+'state/cloudsDestination').set(cloudsDestination);
-    }
-
     updateStockValue = (stockID, value) => {
         const stocks = Object.assign([], this.state.stocks)
         const targetStock = stocks.find( stock => stock.id === stockID)
@@ -204,6 +189,7 @@ export default class Background extends React.Component {
                 <b>Simulation ID: {this.props.location.state.simulationID}</b>
                 <div style = {wrapperStyle}> 
                     <Board 
+                        _FB_PATH = {this._FB_PATH}
                         stocks={this.state.stocks}
                         flows={this.state.flows}
                         arrows={this.state.arrows}

--- a/src/components/Background.js
+++ b/src/components/Background.js
@@ -29,22 +29,6 @@ export default class Background extends React.Component {
         }
     }
 
-    updatePosition = (stockID, x, y) => {
-        const stocks = Object.assign([], this.state.stocks)
-        const targetStock = stocks.find( stock => stock.id === stockID)
-        targetStock.posX = x
-        targetStock.posY = y
-        firebase.database().ref(this._FB_PATH+'state/stocks').set(stocks);
-    }
-
-    updateParameterPosition = (parameterName, x, y) => {
-        const parameters = Object.assign([], this.state.parameters)
-        const targetParameter = parameters.find( parameters => parameters.name === parameterName)
-        targetParameter.posX = x
-        targetParameter.posY = y
-        firebase.database().ref(this._FB_PATH+'state/parameters').set(parameters);
-    }
-
     updateStockValue = (stockID, value) => {
         const stocks = Object.assign([], this.state.stocks)
         const targetStock = stocks.find( stock => stock.id === stockID)
@@ -70,12 +54,12 @@ export default class Background extends React.Component {
     addParameter= (parameterName, value) => {
         const parameters = Object.assign([], this.state.parameters)
         const newParameter = {
+            "id":parameterName,
             "name": parameterName,
             "value":+value,
             "posX": 0,
             "posY": 10, // offset the text a bit so the text doesn't come off the background
         }
-        console.log("add parameter")
         parameters.push(newParameter)
         firebase.database().ref(this._FB_PATH+'state/parameters').set(parameters);
     }
@@ -198,10 +182,7 @@ export default class Background extends React.Component {
                         arrows={this.state.arrows}
                         parameters={this.state.parameters}
                         clouds={this.state.clouds}
-                        stockBeingEdited={this.state.stockBeingEdited}
-                        updatePosition={this.updatePosition}    
-                        updateCloudPosition={this.updateCloudPosition}
-                        updateParameterPosition={this.updateParameterPosition}
+                        stockBeingEdited={this.state.stockBeingEdited}                                                  
                         ></Board>
                     <div>
                         <StockList stocks={this.state.stocks}></StockList>

--- a/src/components/Cloud.js
+++ b/src/components/Cloud.js
@@ -11,49 +11,8 @@ const moveable = {
     cursor: 'move',
 }
 
-export default class Cloud extends React.Component {
-    componentDidMount() {
-        this.makeDraggable()
-    }
-
-    makeDraggable = () => {
-        const id = this.props.flow
-        let draggable = document.getElementById(id);
-        let offset
-
-        const mouseDown = (e) => {
-            draggable = document.getElementById(id);
-            offset = getMousePosition(e);
-            offset.x -= parseFloat(draggable.getAttributeNS(null, "x"));
-            offset.y -= parseFloat(draggable.getAttributeNS(null, "y"));
-            draggable.addEventListener('mousemove', mouseMove)
-        }
-
-        const mouseMove = (e) => {
-            if (!draggable) return
-            e.preventDefault();
-            const coord = getMousePosition(e);
-            this.props.updateCloudPosition(id, coord.x - offset.x, coord.y - offset.y)
-        }
-
-        const mouseUpOrLeave = (e) => {
-            draggable = null
-        }
-
-        // mouse position to svg position
-        const getMousePosition = (e) => {
-            const CTM = draggable.getScreenCTM();
-            return {
-                x: (e.clientX - CTM.e) / CTM.a,
-                y: (e.clientY - CTM.f) / CTM.d
-            };
-        }
-
-        draggable.addEventListener('mousedown', mouseDown)
-        draggable.addEventListener('mouseup', mouseUpOrLeave)
-        draggable.addEventListener('mouseleave', mouseUpOrLeave)
-    }
-
+export default class Cloud extends React.Component {                
+    
     render() {
         const x=this.props.posX
         const y=this.props.posY

--- a/src/components/Cloud.js
+++ b/src/components/Cloud.js
@@ -11,26 +11,13 @@ const moveable = {
     cursor: 'move',
 }
 
-export default class Cloud extends React.Component {                
-    
-    render() {
-        const x=this.props.posX
-        const y=this.props.posY
-        const id=this.props.flow
-        const rx = 40
-        const ry = 20
-        return (
-            <g 
-                x={x} 
-                y={y} 
-                id={id} 
-                style={moveable}
-            >
-                <ellipse cx={x} cy={y} rx={rx} ry={ry} style={stock}/>
-                <foreignObject x={x-rx/1.5} y={y-ry/2} width={80} height={50}>
-                    <div>{"CLOUD"}</div>
-                </foreignObject>    
-            </g>       
-        );
-    }
-}
+const rx = 40
+const ry = 20
+
+export default ({posX, posY, id}) =>  
+    <g x={posX} y={posY} id={id} style={moveable}>
+        <ellipse cx={posX} cy={posY} rx={rx} ry={ry} style={stock}/>
+        <foreignObject x={posX-rx/1.5} y={posY-ry/2} width={80} height={50}>
+            <div>{"CLOUD"}</div>
+        </foreignObject>    
+    </g>

--- a/src/components/Parameter.js
+++ b/src/components/Parameter.js
@@ -5,62 +5,8 @@ const moveableText = {
     fontSize: "large"
 }
 
-export default class Parameter extends React.Component {
-    componentDidMount() {
-        this.makeDraggable()
-    }
-
-    makeDraggable = () => {
-        const id = this.props.parameter.name
-        let draggable = document.getElementById(id);
-        let offset
-
-        const mouseDown = (e) => {
-            console.log("mouse down")
-            draggable = document.getElementById(id);
-            offset = getMousePosition(e);
-            offset.x -= parseFloat(draggable.getAttributeNS(null, "x"));
-            offset.y -= parseFloat(draggable.getAttributeNS(null, "y"));
-            draggable.addEventListener('mousemove', mouseMove)
-        }
-
-        const mouseMove = (e) => {
-            console.log("mouse move")
-            if (!draggable) return
-            e.preventDefault();
-            const coord = getMousePosition(e);
-            console.log(coord.x - offset.x)
-            console.log(coord.y - offset.y)
-            this.props.updateParameterPosition(id, coord.x - offset.x, coord.y - offset.y)
-        }
-
-        const mouseUpOrLeave = (e) => {
-            console.log("mouse up")
-            draggable = null
-        }
-
-        // mouse position to svg position
-        const getMousePosition = (e) => {
-            const CTM = draggable.getScreenCTM();
-            return {
-                x: (e.clientX - CTM.e) / CTM.a,
-                y: (e.clientY - CTM.f) / CTM.d
-            };
-        }
-        draggable.addEventListener('mousedown', mouseDown)
-        draggable.addEventListener('mouseup', mouseUpOrLeave)
-        draggable.addEventListener('mouseleave', mouseUpOrLeave)
-    }
-
-    render() {
-        const x=this.props.parameter.posX
-        const y=this.props.parameter.posY
-        const id=this.props.parameter.name
-        return (<text 
-            x={x} 
-            y={y} 
-            id={id} 
-            style={moveableText}
-        >{id}: {this.props.parameter.value}</text>)
-    }
-}
+export default ({posX, posY, id, value}) => 
+(<text x={posX} y={posY} id={id} style={moveableText}>
+    {id}: {value}
+    </text>
+)

--- a/src/components/Stock.js
+++ b/src/components/Stock.js
@@ -18,71 +18,12 @@ const moveable = {
     cursor: 'move',
 }
 
-export default class Stock extends React.Component {
-    componentDidMount() {
-        this.makeDraggable()
-    }
-
-    makeDraggable = () => {
-        const id = this.props.stock.id
-        let draggable = document.getElementById(id);
-        let offset
-
-        const mouseDown = (e) => {
-            console.log("mouse down")
-            draggable = document.getElementById(id);
-            offset = getMousePosition(e);
-            offset.x -= parseFloat(draggable.getAttributeNS(null, "x"));
-            offset.y -= parseFloat(draggable.getAttributeNS(null, "y"));
-            draggable.addEventListener('mousemove', mouseMove)
-        }
-
-        const mouseMove = (e) => {
-            console.log("mouse move")
-            if (!draggable) return
-            e.preventDefault();
-            const coord = getMousePosition(e);
-            console.log(coord.x - offset.x)
-            console.log(coord.y - offset.y)
-            this.props.updatePosition(id, coord.x - offset.x, coord.y - offset.y)
-        }
-
-        const mouseUpOrLeave = (e) => {
-            console.log("mouse up")
-            draggable = null
-        }
-
-        // mouse position to svg position
-        const getMousePosition = (e) => {
-            const CTM = draggable.getScreenCTM();
-            return {
-                x: (e.clientX - CTM.e) / CTM.a,
-                y: (e.clientY - CTM.f) / CTM.d
-            };
-        }
-
-        draggable.addEventListener('mousedown', mouseDown)
-        draggable.addEventListener('mouseup', mouseUpOrLeave)
-        draggable.addEventListener('mouseleave', mouseUpOrLeave)
-    }
-
-    render() {
-        const x=this.props.stock.posX
-        const y=this.props.stock.posY
-        const id=this.props.stock.id
-        const initValue=this.props.stock.initValue
-        return (
-            <g 
-                x={x} 
-                y={y} 
-                id={id} 
-                style={moveable}
-            >
-                <rect x={x} y={y} width={"5%"} height={"5%"} style={this.props.highlight?stockHighlight:stock}/>
-                <foreignObject x={x} y={y} width="50" height="50">
-                    <div>{id+": "+initValue}</div>                 
-                </foreignObject>    
-            </g>       
-        );
-    }
-}
+export default ({posX, posY, id, initValue, highlight}) => 
+(
+    <g x={posX} y={posY} id={id} style={moveable}>
+        <rect x={posX} y={posY} width={"5%"} height={"5%"} style={highlight?stockHighlight:stock}/>
+        <foreignObject x={posX} y={posY} width="50" height="50">
+            <div>{id+": "+initValue}</div>                 
+        </foreignObject>    
+    </g>
+);


### PR DESCRIPTION
This PR rewrites some important logic that enables draggable components (Stock, Parameter, and Cloud) by applying higher-order component (HOC) design pattern to effectively increase code readability and reusability, minimize code complexity through the following changes.
1. Instead of calling "makeDraggable" method respectively in all those three components, I extract "makeDraggable" function out of draggable components (Stock, Parameter, and Cloud), and create HOCs by decorating stateless components. 
2. Instead of having designated "updatePosition" for those three components respectively, I rewrite one "updatePosition" function that is made configurable by parameter passing. 
3. I also update the UML diagram to match the changes.